### PR TITLE
fix: Remove HttpProxy Adapter from Paperclip

### DIFF
--- a/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
+++ b/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
@@ -10,6 +10,6 @@ module Paperclip
   end
 end
 
-Paperclip.io_adapters.register Paperclip::HttpUrlProxyAdapter do |target|
-  String === target && target =~ Paperclip::HttpUrlProxyAdapter::REGEXP
-end
+# Paperclip.io_adapters.register Paperclip::HttpUrlProxyAdapter do |target|
+#   String === target && target =~ Paperclip::HttpUrlProxyAdapter::REGEXP
+# end

--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -40,5 +40,5 @@ module Paperclip
 end
 
 Paperclip.io_adapters.register Paperclip::UriAdapter do |target|
-  target.kind_of?(URI)
+  target.kind_of?(URI) && target.host =~ /.*github.com$/
 end


### PR DESCRIPTION
This causes paperclip to send a request to a given URL
downloads the content and upload it to S3 (our logic).