### PR TITLE
[IBGBUGCHAT-10593] support certificate content type

### DIFF
--- a/lib/paperclip/content_type_detector.rb
+++ b/lib/paperclip/content_type_detector.rb
@@ -60,7 +60,7 @@ module Paperclip
     end
 
     def type_from_file_contents
-      type_from_mime_magic || type_from_file_command
+      type_from_mime_magic || certificate_type || type_from_file_command
     rescue Errno::ENOENT => e
       Paperclip.log("Error while determining content type: #{e}")
       SENSIBLE_DEFAULT
@@ -74,6 +74,12 @@ module Paperclip
     def type_from_mime_magic
       @type_from_mime_magic ||=
         MimeMagic.by_magic(File.open(@filename)).try(:type)
+    end
+
+    def certificate_type
+      OpenSSL::X509::Certificate.new(File.read(@filename))
+      'application/x-x509-ca-cert'
+    rescue StandardError
     end
   end
 end


### PR DESCRIPTION
### Problem:

`file` command considers the pem files as “text/plain” and `mimemagic` can't detect the pem files _content type_

### Solution:

Try to open a file with `OpenSSL::X509::Certificate`. so If the file opened successfully, it will be a pem file.

### Notes:

_TODO: anything that reviewers should know before reviewing?_

### QC Notes:

_TODO: What parts/flows of the app are affected by this change?_

### Release steps:

_TODO: steps needed for the release. If no special handling needed, please write 'Normal Release'_

### Security:

_TODO: Are the changes exposed publicly or internally?_

_TODO: Do all new endpoints impose proper access to authorized users only?_

### Network:

_TODO: Link to Ops PR if any. Type N/A if none._

_TODO: List new internal/external services communications that were introduced in this PR. Type N/A if none._


### Author checklist:
- [ ] Backward compatibility checked
- [ ] Release steps added
- [ ] Unit tests added (if code logic is touched)
- [ ] JIRA ticket moved to Reviewing
- [ ] Rebased to latest master
- [ ] Commits are clean

### Reviewer checklist:
- [ ] Backward compatibility checked
- [ ] Code quality is acceptable
- [ ] Specs logic coverage
- [ ] Commits are clean
